### PR TITLE
Fix/cdci-opencv

### DIFF
--- a/.github/workflows/vcpkg-install.yml
+++ b/.github/workflows/vcpkg-install.yml
@@ -154,7 +154,7 @@ jobs:
     - name: Install OpenCV
       run: |
         pip3 install numpy
-        pip3 install --no-binary opencv-python opencv-python==4.10.0.84 --verbose
+        pip3 install --no-binary opencv-python opencv-python --verbose
 
     - name: Checkout Repository
       uses: actions/checkout@v4.1.1

--- a/.github/workflows/vcpkg-install.yml
+++ b/.github/workflows/vcpkg-install.yml
@@ -114,7 +114,7 @@ jobs:
         set GSTREAMER_ROOT_X86=${{ github.workspace }}\sensing-dev-gstreamer
         set PATH=%GSTREAMER_ROOT_X86%\lib\glib-2.0\include;%GSTREAMER_ROOT_X86%\lib;%GSTREAMER_ROOT_X86%\include\glib-2.0;%GSTREAMER_ROOT_X86%\include\gstreamer-1.0;%PATH%
         pip install numpy==2.1.1
-        pip3 install --no-binary opencv-python opencv-python==4.10.0.84 --verbose 
+        pip3 install --no-binary opencv-python opencv-python --verbose 
         
     - name: Remove build-time dependencies
       run: |


### PR DESCRIPTION
Visual Studio Enterprise 2022 17.12.35527.113 to 17.12.35707.178

solution:
include chrono explicitly in opencv/modules/gapi/src/streaming/gstreamer/gstreamersource.cpp
opencv 4.10 does not have include chrono
this commit introduce it : https://github.com/opencv/opencv/commit/fe649f4adb5b0d3ca18bb3fd782de61bef7a126d

so if user have latest msvc they need to use opencv 4.11 instead of 4.10